### PR TITLE
bumps httplib2 to the current version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-required = ['oauth2', 'httplib2==0.8.0', 'python-dateutil']
+required = ['oauth2', 'httplib2==0.9.1', 'python-dateutil']
 
 setup(
     name='readability-api',


### PR DESCRIPTION
Was noticing quite a few SSL Handshake errors coming from httplib2. The newest version adds support for more certs and bumping the installed version cleared up the errors.

This pull request bumps the httplib2 version to 0.9.1 in the setup.py