### PR TITLE
Fix ValueError when passing keys as args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/_build/*
 build/
 dist/
 .tox/
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
+    - "3.5"
     - "pypy"
     - "pypy3"
 

--- a/readability/clients.py
+++ b/readability/clients.py
@@ -66,8 +66,8 @@ class ReaderClient(object):
             doesn't have access to (staging, local dev, etc).
 
         """
-        consumer_key = xargs.get('consumer_key', required_from_env('READABILITY_CONSUMER_KEY'))
-        consumer_secret = xargs.get('consumer_secret', required_from_env('READABILITY_CONSUMER_SECRET'))
+        consumer_key = xargs.get('consumer_key') or required_from_env('READABILITY_CONSUMER_KEY')
+        consumer_secret = xargs.get('consumer_secret') or required_from_env('READABILITY_CONSUMER_SECRET')
 
         self.base_url_template = base_url_template
         self.oauth_session = OAuth1Session(consumer_key, consumer_secret, token_key, token_secret)
@@ -326,7 +326,7 @@ class ParserClient(object):
         logger.debug('Initializing ParserClient with base url template %s',
             base_url_template)
 
-        self.token = xargs.get('token', required_from_env('READABILITY_PARSER_TOKEN'))
+        self.token = xargs.get('token', None) or required_from_env('READABILITY_PARSER_TOKEN')
         self.base_url_template = base_url_template
 
     def get(self, url):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import sys
+
 from setuptools import setup
 
 required = [
@@ -7,12 +9,18 @@ required = [
     'requests',
     'requests_oauthlib',
     'httplib2==0.9.1',
-    'python-dateutil'
+    'python-dateutil',
 ]
+
+# Python 2 dependencies
+if sys.version_info[0] == 2:
+    required += [
+        'mock',
+    ]
 
 setup(
     name='readability-api',
-    version='1.0.0',
+    version='1.0.1',
     description='Python client for the Readability Reader and Parser APIs.',
     long_description=open('README.rst').read(),
     author='The Readability Team',
@@ -28,7 +36,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: PyPy',
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
-envlist = py27, py34, pypy, pypy3
+envlist = py27, py35, pypy, pypy3
 
 [testenv]
 commands = py.test
-deps = 
+deps =
     pytest
     requests
     requests_oauthlib
     httplib2==0.9.1
     python-dateutil
+    mock
 passenv =
     READABILITY_CONSUMER_KEY
     READABILITY_CONSUMER_SECRET


### PR DESCRIPTION
Fixes the ValueError thrown when tokens are passed as args to client
constructors. Will no longer call required_from_env when the argument is
already passed in.

Fixes #39